### PR TITLE
docs: add intro (yz2894)

### DIFF
--- a/blog/2024-01-23-yz2894.md
+++ b/blog/2024-01-23-yz2894.md
@@ -1,0 +1,12 @@
+---
+title: About yz2894
+authors: 
+  name: Yufan Zhang
+  title: Connective Media
+tags: [intro]
+---
+
+- Name/Nickname: Yufan
+- Program you're in at Cornell: Connective Media
+- Last TV show you binged, or a movie you watched: Twenty-Five Twenty-One
+- Worst CS Topic: Networks


### PR DESCRIPTION
Create the blog page for the self-introduction of Yufan Zhang (netID: yz2894).